### PR TITLE
feat(auth): expose resendVerificationEmail in AuthContext provider

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -31,6 +31,7 @@ interface AuthContextType {
   logout: () => void;
   refreshTokenFunc: () => Promise<boolean>;
   verifyEmail: (token: string) => Promise<boolean>;
+  resendVerificationEmail: (email: string) => Promise<boolean>; 
   fetchVerificationStatus: () => Promise<void>;
   updateVerificationStatus: (status: User['verificationStatus']) => void;
 }
@@ -269,6 +270,28 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       return false;
     }
   };
+  
+  // Resend verification email
+  const resendVerificationEmail = async (email: string) => {
+    try {
+      const res = await fetch(
+        `${import.meta.env.VITE_API_BASE_URL}/api/auth/verify-email/resend`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email }),
+        }
+      );
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || 'Unable to resend verification email');
+      return true;
+    } catch (error) {
+      console.error('Resend verification email failed:', error);
+      return false;
+    }
+  };
+
+
 
   const logout = () => {
     // If you want to call the logout API endpoint before clearing local state:
@@ -344,6 +367,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       logout, 
       refreshTokenFunc,
       verifyEmail,
+      resendVerificationEmail,
       fetchVerificationStatus,
       updateVerificationStatus
     }}>

--- a/src/pages/auth/VerifyEmail.tsx
+++ b/src/pages/auth/VerifyEmail.tsx
@@ -6,26 +6,23 @@ import { motion } from 'framer-motion';
 const VerifyEmail: React.FC = () => {
   const { token } = useParams<{ token: string }>();
   const [status, setStatus] = useState<'verifying' | 'success' | 'error'>('verifying');
-  const [error, setError] = useState('');
-  const { verifyEmail } = useAuth();
+  const [error, setError] = useState<string>('');
+  const [emailInput, setEmailInput] = useState<string>('');               // for resend
+  const [resendInProgress, setResendInProgress] = useState<boolean>(false);
+  const { verifyEmail, resendVerificationEmail } = useAuth();
   const navigate = useNavigate();
   const isVerifying = useRef(false);
 
   useEffect(() => {
     const verifyEmailToken = async () => {
-      // Prevent multiple verification attempts
       if (isVerifying.current || !token) return;
       isVerifying.current = true;
 
       try {
         const success = await verifyEmail(token);
-        
         if (success) {
           setStatus('success');
-          // Redirect to home page after 2 seconds
-          setTimeout(() => {
-            navigate('/');
-          }, 2000);
+          setTimeout(() => navigate('/'), 2000);
         } else {
           throw new Error('Verification failed');
         }
@@ -40,9 +37,30 @@ const VerifyEmail: React.FC = () => {
     verifyEmailToken();
   }, [token, verifyEmail, navigate]);
 
+  const handleResend = async () => {
+    if (!emailInput) {
+      setError('Please enter your email address to resend.');
+      return;
+    }
+    setResendInProgress(true);
+    setError('');
+    try {
+      const ok = await resendVerificationEmail(emailInput);
+      if (ok) {
+        setError('Verification email resent! Check your inbox.');
+      } else {
+        throw new Error('Unable to resend verification link');
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Error sending verification link');
+    } finally {
+      setResendInProgress(false);
+    }
+  };
+
   return (
     <div className="pt-16 min-h-screen bg-gray-50 flex items-center justify-center px-4">
-      <motion.div 
+      <motion.div
         className="max-w-md w-full bg-white rounded-xl shadow-sm overflow-hidden p-8"
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
@@ -54,8 +72,8 @@ const VerifyEmail: React.FC = () => {
               <h2 className="text-2xl font-bold text-gray-900 mb-4">Verifying your email...</h2>
               <div className="flex justify-center">
                 <svg className="animate-spin h-8 w-8 text-primary-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
                 </svg>
               </div>
             </>
@@ -64,10 +82,12 @@ const VerifyEmail: React.FC = () => {
           {status === 'success' && (
             <>
               <h2 className="text-2xl font-bold text-gray-900 mb-4">Email Verified!</h2>
-              <p className="text-gray-600 mb-4">Your email has been successfully verified. Redirecting you to the home page...</p>
+              <p className="text-gray-600 mb-4">
+                Your email has been successfully verified. Redirecting you to the home page...
+              </p>
               <div className="flex justify-center">
                 <svg className="h-12 w-12 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7"></path>
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
                 </svg>
               </div>
             </>
@@ -77,12 +97,31 @@ const VerifyEmail: React.FC = () => {
             <>
               <h2 className="text-2xl font-bold text-gray-900 mb-4">Verification Failed</h2>
               <p className="text-red-600 mb-4">{error}</p>
+
               <button
                 onClick={() => navigate('/signup')}
                 className="mt-4 bg-primary-600 text-white py-2 px-4 rounded-md hover:bg-primary-700 transition-colors"
               >
                 Return to Sign Up
               </button>
+
+              <div className="mt-6">
+                <p className="text-sm text-gray-700 mb-2">Resend verification email:</p>
+                <input
+                  type="email"
+                  placeholder="Your email address"
+                  value={emailInput}
+                  onChange={e => setEmailInput(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md mb-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                />
+                <button
+                  onClick={handleResend}
+                  disabled={resendInProgress}
+                  className="w-full bg-[#F2631F] text-white py-2 rounded-md hover:bg-orange-600 transition-colors disabled:bg-gray-400"
+                >
+                  {resendInProgress ? 'Sending...' : 'Resend Link'}
+                </button>
+              </div>
             </>
           )}
         </div>
@@ -91,4 +130,4 @@ const VerifyEmail: React.FC = () => {
   );
 };
 
-export default VerifyEmail; 
+export default VerifyEmail;


### PR DESCRIPTION
- Add `resendVerificationEmail` to `AuthContextType` definition
- Implement `resendVerificationEmail(email: string): Promise<boolean>` in `AuthProvider`: • Calls POST /api/auth/verify-email/resend • Returns `true` on HTTP 200, logs and returns `false` on error
- Include `resendVerificationEmail` in `<AuthContext.Provider value={...}>`
- Update `useAuth()` hook consumers to have access to the new method
- Enables frontend components to trigger the “resend verification email” flow directly